### PR TITLE
ci: GitHub actions CI & CD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,19 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+    - name: Cache python env
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
     - name: Install deps
+      env:
+        PIP_UPGRADE: True
+        UPGRADE_STRATEGY: eager
       run: |
-        python -m pip install --upgrade pip flit
+        python -m pip install pip flit
         python -m flit install --deps develop
+
     - name: Build and publish with Flit
       env:
         FLIT_USERNAME:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,6 @@ jobs:
 
     - name: Build and publish with Flit
       env:
-        FLIT_USERNAME:
-        FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
+        FLIT_USERNAME: __token__
+        FLIT_PASSWORD: ${{ secrets.FLIT_TOKEN }}
       run: python -m flit publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: CD - Publish package
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: CD - Publish package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install deps
+      run: |
+        python -m pip install --upgrade pip flit
+        python -m flit install --deps develop
+    - name: Build and publish with Flit
+      env:
+        FLIT_USERNAME:
+        FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
+      run: python -m flit publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: CD - Release package
+name: CD - Make release PR
 
 on:
   push:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: CD - Make release PR
+name: CD - Release Please
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,19 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+    - name: Cache python env
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
     - name: Install deps
+      env:
+        PIP_UPGRADE: True
+        UPGRADE_STRATEGY: eager
       run: |
-        python -m pip install --upgrade pip flit
+        python -m pip install pip flit
         python -m flit install --deps develop
+
     - name: Check format with black
       run: python -m black -v --check .
     - name: Lint with flakehell
@@ -47,10 +56,19 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache python env
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
     - name: Install deps
+      env:
+        PIP_UPGRADE: True
+        UPGRADE_STRATEGY: eager
       run: |
-        python -m pip install --upgrade pip flit
+        python -m pip install pip flit
         python -m flit install --deps develop
+
     - name: Run tests with pytest
       run: pytest -v --cov=incipyt --cov-report=xml
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
         python -m pip install --upgrade pip flit
         python -m flit install --deps develop
     - name: Check format with black
-      run: python -m black --check incipyt
+      run: python -m black -v --check .
     - name: Lint with flakehell
-      run: python -m flakehell lint incipyt
+      run: python -m flakehell lint -v
 
   test:
     name: Tests
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pip flit
         python -m flit install --deps develop
     - name: Run tests with pytest
-      run: pytest --cov=incipyt --cov-report=xml
+      run: pytest -v --cov=incipyt --cov-report=xml
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,15 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
     needs: lint
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
+    runs-on: ${{ matrix.os }}
+    env:
+      _OS: ${{ matrix.os }}
+      _PY: ${{ matrix.python-version }}
 
     steps:
     - name: Checkout
@@ -49,4 +52,9 @@ jobs:
         python -m pip install --upgrade pip flit
         python -m flit install --deps develop
     - name: Run tests with pytest
-      run: pytest
+      run: pytest --cov=./ --cov-report=xml
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+        env_vars: _OS,_PY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pip flit
         python -m flit install --deps develop
     - name: Run tests with pytest
-      run: pytest --cov=./ --cov-report=xml
+      run: pytest --cov=incipyt --cov-report=xml
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: CI - Test package
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install deps
+      run: |
+        python -m pip install --upgrade pip flit
+        python -m flit install --deps develop
+    - name: Check format with black
+      run: python -m black --check incipyt
+    - name: Lint with flakehell
+      run: python -m flakehell lint incipyt
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install deps
+      run: |
+        python -m pip install --upgrade pip flit
+        python -m flit install --deps develop
+    - name: Run tests with pytest
+      run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Run tests with pytest
       run: pytest -v --cov=incipyt --cov-report=xml
-    - name: "Upload coverage to Codecov"
+    - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "build",
   "pre-commit",
   "black",
-  "flake8!=3.9.1",
+  "flake8<=3.9.0",
   "flakehell",
   "flake8-bandit",
   "flake8-bugbear",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dev = [
 ]
 test = [
   "pytest-cov",
-  "pytest-html",
 ]
 doc = [
   "m2r",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "build",
   "pre-commit",
   "black",
-  "flake8<=3.9.0",
+  "flake8",
   "flakehell",
   "flake8-bandit",
   "flake8-bugbear",
@@ -63,6 +63,8 @@ exclude = [
   ".env",
   ".git",
 ]
+# Fix combatibility with flake8 3.9.[1-2] as of writing
+extended_default_ignore = []
 
 [tool.flakehell.plugins]
 flake8-bandit = ["+*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
   "pep8-naming",
 ]
 test = [
-  "pytest-coverage",
+  "pytest-cov",
   "pytest-html",
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,7 @@ flake8-use-fstring = ["+*"]
 pep8-naming = ["+*"]
 pycodestyle = ["+*", "-W503", "-E501"]
 pyflakes = ["+*"]
+
+[tool.flakehell.exceptions."tests/*.py"]
+flake8-bandit = ["-S101"] # Asserts
+flake8-docstrings = ["-*"]

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,5 @@
+import incipyt  # noqa: F401
+
+
+def test_dummy():
+    assert True


### PR DESCRIPTION
First draft for CI/CD.

# Features

- Keep `release-please` action in a separate workflow
- Cache python env according to platform, python path (exact version) and `pyproject.toml` hash for fast CI
- Run `flakehell` and `black` (check-only) on pushes/PRs to ensure consistent codestyle
- Run `pytest` on pushes/PR on a matrix of python versions and platforms
- Upload code coverage to Codecov on pushes/PR
- For draft PRs, tests & checks are skipped
- Run `flit publish` on release to build and publish package (token stored as gh secret)

# Other adjustments

- Add dummy test
- Configure flakehell for tests
