### PR TITLE
fix: First design proposal for TemplateDict

### DIFF
--- a/incipyt/_internal/utils.py
+++ b/incipyt/_internal/utils.py
@@ -53,6 +53,15 @@ class MultipleValues:
             ),
         )
 
+    def __repr__(self):
+        return f"{type(self).__name__}({self._values})"
+
+    def __eq__(self, other):
+        try:
+            return self._values == other._values
+        except AttributeError:
+            return False
+
 
 def append_unique(config, value):
     assert isinstance(config, collections.abc.MutableSequence)

--- a/incipyt/_internal/utils.py
+++ b/incipyt/_internal/utils.py
@@ -70,24 +70,74 @@ def append_unique(config, value):
         config.append(value)
 
 
-def set_item(config, key, value):
-    assert isinstance(config, collections.abc.MutableMapping)
-
-    if key in config:
-        if config[key] != value:
-            config[key] = MultipleValues(value, config[key])
-    else:
-        config[key] = value
+def is_not_string_sequence(obj):
+    return (
+        isinstance(obj, collections.abc.Sequence)
+        and not isinstance(obj, collections.abc.ByteString)
+        and not isinstance(obj, str)
+    )
 
 
-def set_items(config, raw_config, transformer=None):
-    assert isinstance(config, collections.abc.MutableMapping)
-    assert isinstance(raw_config, collections.abc.Mapping)
+class TemplateDict(collections.UserDict):
+    def __init__(self, mapping=None):
+        # If an existing mapping is provided, this class will act like a proxy
+        # around it
+        self.data = {} if mapping is None else mapping
 
-    for key, value in raw_config.items():
-        if isinstance(value, collections.abc.Mapping):
-            if key not in config:
-                config[key] = {}
-            set_items(config[key], value, transformer=transformer)
+    def __setitem__(self, keys, value):
+        if not is_not_string_sequence(keys):
+            keys = [keys]
+
+        self._set_item_from_chained_keys(self, keys, value)
+
+    def set_items(self, mapping, transformer=None):
+        self._set_items(self, mapping, transformer=transformer)
+
+    @staticmethod
+    def _set_item(mapping, key, value):
+        assert isinstance(mapping, collections.abc.Mapping)
+
+        if key in mapping:
+            existing_value = mapping[key]
+            if value == existing_value:
+                return
+            value = MultipleValues(value, existing_value)
+
+        # Check if processed mapping is a proxy object or not to avoid endless
+        # recursion on overriden __setitem__
+        if hasattr(mapping, "data"):
+            mapping.data[key] = value
         else:
-            set_item(config, key, transformer(value) if transformer else value)
+            mapping[key] = value
+
+    @staticmethod
+    def _set_item_from_chained_keys(mapping, keys, value):
+        assert isinstance(mapping, collections.abc.MutableMapping)
+        assert is_not_string_sequence(keys)
+
+        keys = list(keys)
+        key = keys.pop(0)
+
+        if not keys:
+            TemplateDict._set_item(mapping, key, value)
+            return
+
+        if key not in mapping:
+            mapping[key] = {}
+        TemplateDict._set_item_from_chained_keys(mapping[key], keys, value)
+
+    @staticmethod
+    def _set_items(mapping, added_mapping, transformer=None):
+        assert isinstance(mapping, collections.abc.MutableMapping)
+        assert isinstance(added_mapping, collections.abc.Mapping)
+
+        for key, value in added_mapping.items():
+            if isinstance(value, collections.abc.Mapping):
+                if key not in mapping:
+                    mapping[key] = {}
+                TemplateDict._set_items(mapping[key], value, transformer=transformer)
+
+            else:
+                TemplateDict._set_item(
+                    mapping, key, transformer(value) if transformer else value
+                )

--- a/incipyt/actions/setuptools.py
+++ b/incipyt/actions/setuptools.py
@@ -63,8 +63,7 @@ class Setuptools:
             "build-backend": "setuptools.build_meta",
         }
 
-        utils.set_items(
-            setup,
+        setup.set_items(
             {
                 "metadata": {
                     "author_email": "{AUTHOR_NAME} <{AUTHOR_EMAIL}>",
@@ -74,8 +73,7 @@ class Setuptools:
             },
             utils.Requires,
         )
-        utils.set_items(
-            setup,
+        setup.set_items(
             {
                 "metadata": {
                     "version": "{PACKAGE_VERSION}",
@@ -92,28 +90,16 @@ class Setuptools:
             ),
         )
 
-        if "metadata" not in setup:
-            setup["metadata"] = {}
-        utils.set_item(
-            setup["metadata"],
-            "name",
-            utils.Requires("{PROJECT_NAME}", sanitizer=sanitizers.project),
+        setup["metadata", "name"] = utils.Requires(
+            "{PROJECT_NAME}", sanitizer=sanitizers.project
         )
 
-        if "options" not in setup:
-            setup["options"] = {}
-        utils.set_item(
-            setup["options"],
-            "packages",
-            utils.Requires("{PROJECT_NAME}", sanitizer=sanitizers.package),
+        setup["options", "packages"] = utils.Requires(
+            "{PROJECT_NAME}", sanitizer=sanitizers.package
         )
 
-        if "options.package_data" not in setup:
-            setup["options.package_data"] = {}
-        utils.set_item(
-            setup["options.package_data"],
-            "*",
-            utils.Requires("{PACKAGE_DATA}/*", confirmed=True, PACKAGE_DATA="data"),
+        setup["options.package_data", "*"] = utils.Requires(
+            "{PACKAGE_DATA}/*", confirmed=True, PACKAGE_DATA="data"
         )
 
         hierarchy.register_template(
@@ -155,30 +141,19 @@ setuptools.setup()
 
     def _hook_classifier(self, hierarchy, value):
         setup = hierarchy.get_configuration(CfgIni.make("setup.cfg"))
-        if "metadata" not in setup:
-            setup["metadata"] = {}
-        if "classifiers" not in setup["metadata"]:
-            setup["metadata"]["classifiers"] = []
+        setup["metadata", "classifiers"] = []
 
         utils.append_unique(setup["metadata"]["classifiers"], value)
 
     def _hook_dependancy(self, hierarchy, value):
         setup = hierarchy.get_configuration(CfgIni.make("setup.cfg"))
-        if "options.extras_require" not in setup:
-            setup["options.extras_require"] = {}
-        if "dev" not in setup["options.extras_require"]:
-            setup["options.extras_require"]["dev"] = []
+        setup["options.extras_require", "dev"] = []
 
         utils.append_unique(setup["options.extras_require"]["dev"], value)
 
     def _hook_url(self, hierarchy, url_kind, url_value):
         setup = hierarchy.get_configuration(CfgIni.make("setup.cfg"))
-        if "metadata" not in setup:
-            setup["metadata"] = {}
-        if "project_urls" not in setup["metadata"]:
-            setup["metadata"]["project_urls"] = {}
-
-        utils.set_item(setup["metadata"]["project_urls"], url_kind, url_value)
+        setup["metadata", "project_urls", url_kind] = url_value
 
     def __str__(self):
         return "setuptools"

--- a/incipyt/system.py
+++ b/incipyt/system.py
@@ -8,6 +8,8 @@ import subprocess
 
 import click
 
+from incipyt._internal import utils
+
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +186,7 @@ class Hierarchy:
             )
             self._configurations[config_root] = {}
 
-        return self._configurations[config_root]
+        return utils.TemplateDict(self._configurations[config_root])
 
     def register_template(self, template_root, template):
         """Register a Jinja template associated to the relative path `config_root`.

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,5 +1,0 @@
-import incipyt  # noqa: F401
-
-
-def test_dummy():
-    assert True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,52 @@
+import pytest
+
+from incipyt._internal.utils import TemplateDict, MultipleValues
+
+
+class TestTemplateDict:
+    @pytest.fixture
+    def empty_td(self):
+        return TemplateDict()
+
+    @pytest.fixture
+    def simple_td(self):
+        return TemplateDict({"1": {"2": {"3": None}}})
+
+    @pytest.mark.parametrize(
+        "td, res",
+        (
+            ("empty_td", {"1": True}),
+            ("simple_td", {"1": MultipleValues(True, {"2": {"3": None}})}),
+        ),
+    )
+    def test_setitem(self, td, res, request):
+        td = request.getfixturevalue(td)
+        td["1"] = True
+
+        assert td == res
+
+    @pytest.mark.parametrize(
+        "td, res",
+        (
+            ("empty_td", {"1": {"2": {"3": True}}}),
+            ("simple_td", {"1": {"2": {"3": MultipleValues(True, None)}}}),
+        ),
+    )
+    def test_chained_setitem(self, td, res, request):
+        td = request.getfixturevalue(td)
+        td["1", "2", "3"] = True
+
+        assert td == res
+
+    @pytest.mark.parametrize(
+        "td, res",
+        (
+            ("empty_td", {"1": {"2": True}}),
+            ("simple_td", {"1": {"2": MultipleValues(True, {"3": None})}}),
+        ),
+    )
+    def test_set_items(self, td, res, request):
+        td = request.getfixturevalue(td)
+        td.set_items({"1": {"2": True}})
+
+        assert td == res


### PR DESCRIPTION
- `append_unique` needs to be moved as a class member
- docs need update
- still unsure about how `TemplateDict` internals work

Maybe we should ditch
```py
template_dict["first", "second", "third"] = something
```
in favor of
```py
template_dict["first"] = {"second": {"third": something}}
```
and check for overrides in `__getitem__`