### PR TITLE
docs: new commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,30 @@
+
+
+## type(scope): title under 50 chars
+##
+## Mandatory paragraph explaining WHY the changes are needed.
+##
+## Optional paragraphs detailing the changes.
+##
+## Closes #x
+## Co-authored-by: John <john.doe@example.com>
+#
+# The commit type should be one of: chore, feat, fix, perf, ref, rev.
+# The scope is optional, it should be set when the changes are related
+# to a plugin e.g. "fix(sphinx): broken home page url".
+#
+# Remember that this commit message will be read on two occasions:
+#
+# * during the code review, tonight, "what am I reviewing again?"
+# * during a git blame, in 5 years, "why is this line needed again?"
+#
+# During a code review, we expect to understand the overall system and
+# all the implications of your changes. The commit message should
+# contain an abstract of the system being modified and recall the
+# purpose of the changes.
+#
+# During a git-blame, we expect to remember the purpose of a specific
+# line of code. Reading the commit diff and the commit message should
+# give all the necessary information. If you don't feel like all your
+# changes are correctly explained, maybe you should add a comment in
+# the source code or isolate some changes in a new commit.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The complete setup instruction are found on the [dev-instructions]. Below is the
 
     $ git clone https://github.com/NotANameServer/incipyt
     $ cd incipyt
+    $ git config commit.template .gitmessage
     $ python -m venv --upgrade-deps .env
 	$ source .env/bin/activate
     $ python -m pip install --upgrade flit

--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ linters, formatters, etc.
 
 incipyt is released under the MIT license and is open to contributions
 
-The complete setup instruction are found on the [dev-instructions]. Below is the minimum to get started:
+The complete setup instruction are found on the [dev-instructions]. Below is
+the minimum to get started:
 
     $ git clone https://github.com/NotANameServer/incipyt
     $ cd incipyt
     $ git config commit.template .gitmessage
     $ python -m venv --upgrade-deps .env
-	$ source .env/bin/activate
+    $ source .env/bin/activate
     $ python -m pip install --upgrade flit
     $ python -m flit install --pth-file --deps develop
     $ python -m pytest -vv tests


### PR DESCRIPTION
Often users don't know how to respect our commit guidelines, we loose
time explaining them how to write good commit messages. Using this
template the default commit message is changed to include a minimalistic
tutorial.

For now this template is opt-in, you can enable it via the following
command:

    git config commit.template .gitmessage