### PR TITLE
feat(setuptools): specific var for python_requires

### DIFF
--- a/incipyt/tools/setuptools.py
+++ b/incipyt/tools/setuptools.py
@@ -1,9 +1,14 @@
 import os
 import textwrap
+import sys
 
 from incipyt import commands, project, signals, tools
 from incipyt._internal import sanitizers, templates
 from incipyt._internal.dumpers import CfgIni, TextFile, Toml
+
+# as of may 2022, the latest stable release of most bsd/linux
+# distributions ship a python whoose verion is at least 3.9
+LINUX_MIN_PYTHON_VERSION = (3, 9)
 
 
 class Setuptools(tools.Tool):
@@ -97,7 +102,9 @@ class Setuptools(tools.Tool):
             "python_requires": templates.StringTemplate(
                 ">={AUDIENCE_PYTHON_VERSION}",
                 sanitizer=sanitizers.version,
-                AUDIENCE_PYTHON_VERSION="3.7",
+                AUDIENCE_PYTHON_VERSION="{0[0]}.{0[1]}".format(  # noqa: FS002
+                    min(sys.version_info, LINUX_MIN_PYTHON_VERSION)
+                ),
             ),
         }
 

--- a/incipyt/tools/setuptools.py
+++ b/incipyt/tools/setuptools.py
@@ -45,7 +45,7 @@ class Setuptools(tools.Tool):
 
             [options]
             packages = {PROJECT_NAME}
-            python_requires = >={PYTHON_VERSION}
+            python_requires = >={AUDIENCE_PYTHON_VERSION}
 
             [options.package_data]
             * = {PACKAGE_DATA}/*
@@ -95,9 +95,9 @@ class Setuptools(tools.Tool):
                 sanitizer=sanitizers.package,
             ),
             "python_requires": templates.StringTemplate(
-                ">={PYTHON_VERSION}",
+                ">={AUDIENCE_PYTHON_VERSION}",
                 sanitizer=sanitizers.version,
-                PYTHON_VERSION="3.7",
+                AUDIENCE_PYTHON_VERSION="3.7",
             ),
         }
 


### PR DESCRIPTION
The PYTHON_VERSION is the python version currently in use, it does not
necessary correspond to the minimal python version that'll be supported
for the project. One can use py3.10 on his system (latest python as of
2022) but want his project to be compatible with py3.9 (as packaged in
debian bulleyes). This commit changes the variable to
AUDIENCE_PYTHON_VERSION which better reflect the purpose of the
variable.

---

## chore(setuptools): bump audience py version to 3.9

As of the 26 of May 2022, the version of the python package in major
distributions are:

alpine: 3.9
Arch Linux: 3.10
CentOS 9: 3.9
Debian bulleye: 3.9
Fedora 36: 3.10
FreeBSD: 3.10
gentoo: 3.10
openSUSE Tumbleweed: 3.10
Ubuntu jammy: 3.10
slackware 15: 3.9