### PR TITLE
feat: advanced logging configuration

### DIFF
--- a/incipyt/__main__.py
+++ b/incipyt/__main__.py
@@ -2,12 +2,17 @@ import logging
 import os
 import pathlib
 import sys
+import warnings
 
 import click
 
 from incipyt import tools, project
 
+
 logger = logging.getLogger(__name__)
+DEFAULT_LOGGING_LEVEL = logging.WARNING
+DEFAULT_FORMAT = "[%(levelname)s] %(message)s"
+DEBUG_FORMAT = "%(asctime)s [%(levelname)s] <%(funcName)s> %(message)s"
 
 
 @click.command(help="incipyt is a command-line tool that bootstraps a Python project.")
@@ -18,14 +23,17 @@ logger = logging.getLogger(__name__)
     type=click.Path(file_okay=False),
     callback=lambda _ctx, _param, _path: pathlib.Path(_path),
 )
+@click.option("-v", "--verbose", count=True)
+@click.option("-s", "--silent", count=True)
 @click.version_option()
 @click.option(
     "--check-build",
     is_flag=True,
     help="Build the package after initialization of all files and folders.",
 )
-def main(folder, check_build):
-    logging.basicConfig(level="INFO")
+def main(folder, verbose, silent, check_build):
+    log_level = DEFAULT_LOGGING_LEVEL - verbose * 10 + silent * 10
+    setup_logging(max(logging.NOTSET, min(log_level, logging.CRITICAL)))
 
     if folder == pathlib.Path():
         if any(folder.resolve().iterdir()):
@@ -41,22 +49,67 @@ def main(folder, check_build):
     tools_to_install = [tools.Git(), tools.Venv(), tools.Setuptools(check_build)]
 
     for tool in tools_to_install:
-        logger.info("Add %s to project structure.", tool)
+        logger.info("Using %s", tool)
         tool.add_to_structure()
 
-    logger.info("Mkdir folder for project structure on %s.", os.fspath(folder))
+    logger.info("The project will be created at %s", folder.resolve())
     project.structure.mkdir(folder)
 
     for tool in tools_to_install:
-        logger.info("Running pre-script for %s.", tool)
+        logger.info("Running pre-script for %s...", tool)
         tool.pre(folder)
 
     logger.info("Commit project structure.")
     project.structure.commit()
 
     for tool in tools_to_install:
-        logger.info("Running post-script for %s.", tool)
+        logger.info("Running post-script for %s...", tool)
         tool.post(folder)
+
+    logger.info("All done.")
+
+
+class ColoredFormatter(logging.Formatter):
+    """Classic formatter with colored [LEVEL]."""
+
+    colors = {10: (34, 49), 20: (32, 49), 30: (33, 49), 40: (31, 49), 50: (37, 41)}
+
+    def format(self, record):  # noqa: A003, D102
+        fg, bg = type(self).colors.get(record.levelno, (32, 49))
+        record.levelname = f"\033[1;{fg}m\033[1;{bg}m{record.levelname}\033[0m"
+        return super().format(record)
+
+
+def supports_color(stream):
+    """Determine if the given stream support colors."""
+    platform_is_supported = True
+    stream_is_a_tty = hasattr(stream, "isatty") and stream.isatty()
+    return (platform_is_supported or "ANSICON" in os.environ) and stream_is_a_tty
+
+
+def setup_logging(verbosity):
+    """Set up the root logger.
+
+    Replace the current root logger handlers by a new
+    :class:`logging.StreamHandler` with the correct level and formatter.
+
+    When the requested :param verbosity: is more verbose than
+    :data:`logging.DEBUG` then the python warnings are logged too.
+
+    :param verbosity int: the verbosity level to use on the root logger
+    """
+    root_logger = logging.getLogger("" if __name__ == "__main__" else __package__)
+    stdout = logging.StreamHandler()
+    f_cls = ColoredFormatter if supports_color(stdout.stream) else logging.Formatter
+    f_format = DEFAULT_FORMAT if verbosity > logging.DEBUG else DEBUG_FORMAT
+    stdout.formatter = f_cls(f_format)
+    root_logger.handlers.clear()
+    root_logger.handlers.append(stdout)
+    root_logger.level = max(verbosity, logging.DEBUG)
+    logger.level = root_logger.level - 10
+    if verbosity < logging.DEBUG:
+        logging.captureWarnings(True)
+        warnings.filterwarnings("default")
 
 
 # Remove '' and current working directory from the first entry of sys.path, if

--- a/incipyt/tools/git.py
+++ b/incipyt/tools/git.py
@@ -1,13 +1,23 @@
+import logging
 import os
+import shutil
+import sys
 
 from incipyt import commands, project, signals, tools
 from incipyt._internal.dumpers import TextFile
+
+
+logger = logging.getLogger(__name__)
 
 
 class Git(tools.Tool):
     """Scripts to add Git to :class:`incipyt.project._Structure`."""
 
     def __init__(self):
+        if not shutil.which("git"):
+            logger.error("%r is missing from the PATH. Abort.", "git")
+            sys.exit(1)
+
         signals.vcs_ignore.connect(self._slot)
 
     def add_to_structure(self):


### PR DESCRIPTION
Everything was logged with no way of silencing the logger, the result
was that the tool was very noisy.

We changed the base verbosity from INFO to WARNING and we added two cli
options to change it:

* -s/--silent: decrease verbosity
* -v/--verbose: increase verbosity

The two options can be repeated: -v: INFO, -vv DEBUG, -vvv DEBUG with
python warnings. -s: ERROR, -ss: CRITICAL (unused for now).

The logger used in `__main__.py` is one step more verbose than the rest
of the program. When the verbosity is configured on WARNING elsewhere,
it is INFO inside of `__main__.py`. This gives just enough messages when
used by regular users.

Closes: #22

---

**feat: crash when git is missing**

Until we make it configurable, `git` is a mandatory dependency of
incipyt, running incipyt on a system that lacks git is not supported
and was throwing an obscure error on the first git command executed.

When git is missing from the PATH, we now log an explicit error and
exit.