### PR TITLE
fix(venv): --upgrade-deps option missing on mint

### DIFF
--- a/incipyt/tools/venv.py
+++ b/incipyt/tools/venv.py
@@ -17,7 +17,7 @@ class Venv(tools.Tool):
         :type workon: :class:`pathlib.Path`
         """
         env_path = workon / ".env"
-        commands.venv(["--upgrade-deps", os.fspath(env_path)])
+        commands.venv([os.fspath(env_path)])
         commands.setenv_python_cmd(
             env_path.resolve() / ("Scripts" if os.name == "nt" else "bin") / "python"
         )


### PR DESCRIPTION
The `--upgrade-deps` option is a recent addition to venv. This option
is missing from the python3-venv packages ship with the latest stable
Mint (Linux Mint Una 20.3) which cause incipyt to crash when
bootstraping a project.

It is safer to not use this option until it is deployed on all major
distributions.

Closes #27